### PR TITLE
feat: port to 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id "net.fabricmc.fabric-loom-remap" version "1.14.10"
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,17 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
+loader_version=0.18.4
+
 
 # Mod Properties
-mod_version=1.1.0-beta-1.21.4
+mod_version=1.2.0-beta-1.21.11
 maven_group=com.jibben.wynncraftdynamicweather
 archives_base_name=wynncraft-dynamic-weather
 
 # Dependencies
-fabric_version=0.115.1+1.21.4
-modmenu_version=13.0.1
-clothconfig_version=17.0.144
+fabric_version=0.141.1+1.21.11
+modmenu_version=17.0.0-beta.1
+clothconfig_version=21.11.153

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
 		"wynncraft-dynamic-weather.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.15.11",
-		"minecraft": "~1.21",
+		"fabricloader": ">=0.18.4",
+		"minecraft": "~1.21.11",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
Ports this mod to 1.21.11

A prebuilt version can be found [here](https://github.com/DevChromium/Wynncraft-Dynamic-Weather/releases/tag/1.21.11)